### PR TITLE
Stop including stdcompat.h

### DIFF
--- a/pyml_stubs.c
+++ b/pyml_stubs.c
@@ -11,7 +11,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <errno.h>
-#include <stdcompat.h>
+#include <caml/alloc.h>
 #include <assert.h>
 #include "pyml_stubs.h"
 


### PR DESCRIPTION
Starting with stdcompat 21.0 this file is no longer provided.

The only reason why it was included was to provide access to the
`caml_alloc_initialized_string` primitive which is actually exported
by caml/alloc.h.

It has been verified that this was already the case in OCaml 4.11,
which is the oldest version of the OCaml compiler pyml will now be supporting.